### PR TITLE
Fix for 'strike price' as a result of an HTML structure change

### DIFF
--- a/yahoo/finance/yahoo.finance.options.xml
+++ b/yahoo/finance/yahoo.finance.options.xml
@@ -192,7 +192,7 @@
 			
 			var expiresQuery = y.xpath( 
 				data,
-				"//table[@class='yfnc_mod_table_title1']/tbody/tr/td[last()]"
+				"//table[@class='yfnc_mod_table_title1']/tr/td[last()]/p"
 			);
 
 			var expiryDay = getExpiration();


### PR DESCRIPTION
Hi All-

I've committed a fix for an issue someone brought to my attention a couple of days ago. It is a very simple change but critical nonetheless for retrieving the strike price. The change introduced is in response to an HTML structure change to the following URL:

http://finance.yahoo.com/q/op?s=[insert stock symbol here]+Options

Yahoo has swapped the hierarchical order of the 'a' and 'strong' elements for the strike price of a given stock symbol. If you could please pull this change when you get a chance I'd appreciate it.

Thanks,

Thomas
