### PR TITLE
htmlstring table, same as 'html' but flattens output to a string

### DIFF
--- a/data/htmlstring.xml
+++ b/data/htmlstring.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+  <meta>
+    <author>Todd Vierling</author>
+    <description>HTML selector that returns a flat, escaped string rather than a node tree. Suitable for use with Pipes and other applications wishing to embed HTML in another XML-like container.</description>
+    <sampleQuery>select * from {table} where url='http://www.yahoo.com/' and xpath='//a'</sampleQuery>
+  </meta>
+  <bindings>
+  <select itemPath="" produces="XML">
+    <urls>
+      <url>{url}</url>
+    </urls>
+    <inputs>
+      <key id="url" type="xs:string" paramType="variable" required="true" />
+      <key id="xpath" type="xs:string" paramType="variable" required="false" />
+    </inputs>
+      <execute><![CDATA[
+var results = y.rest(url).accept('text/html').get().response;
+if (xpath) results = y.xpath(results, xpath);
+response.object = results.toXMLString();
+      ]]></execute>
+    </select>
+  </bindings>
+</table>
+


### PR DESCRIPTION
This is a table I wrote primarily for use with Pipes, where a YQL query to the 'html' table outputs a node tree, but I actually need escaped HTML output as a single block of text (for use in the description section of RSS feed output). Its usage is basically identical to 'html' (including xpath support) but different in output.
