### PR TITLE
Adding the Halo Reach API to Open Data Tables for YQL

### DIFF
--- a/Bungie/Reach/Bungie.Reach.GetPlayerRenderedVideos.xml
+++ b/Bungie/Reach/Bungie.Reach.GetPlayerRenderedVideos.xml
@@ -6,7 +6,7 @@
     <sampleQuery>SELECT * FROM bungie.reach.videos WHERE gamertag="cbjoe" AND iPage=0</sampleQuery>
   </meta>
   <bindings>
-    <select itemPath="bungie.reach.videos" produces="JSON">
+    <select itemPath="" produces="JSON">
       <urls>
         <url>http://www.bungie.net/api/reach/reachapijson.svc/file/videos/{identifier}/{gamertag}/{iPage}</url>
       </urls>


### PR DESCRIPTION
I'm starting to define data tables for the Halo Reach API. If my experience of adding this first data table is good, I will proceed to add all currently available data tables.

Halo Reach has millions of users worldwide, and a lively community online. The developer, Bungie, one of the world's top game studios, leads the industry in console gaming data and web integration. Data tables include gaming stats and content such as videos and screenshots, captured from millions of players.

My blog post on using the Halo Reach API through YQL:
http://www.timacheson.com/Blog/2010/oct/halo_reach_api_demo

My blog post on the launch of Halo Reach:
http://www.timacheson.com/Blog/2010/sep/halo_reach_launch

Enjoy!
