### PR TITLE
Fix broken etsy.listings table to work with Etsy's v2 API

### DIFF
--- a/etsy/etsy.listings.xml
+++ b/etsy/etsy.listings.xml
@@ -2,6 +2,7 @@
 <table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
   <meta>
     <author>Rasmus Lerdorf</author>
+    <author>Reid Burke</author>
     <documentationURL>http://developer.etsy.com/docs</documentationURL>
     <description>Etsy.com Listings API</description>
     <sampleQuery>select * from etsy.listings where color='AAAA22' and api_key=123456789</sampleQuery>
@@ -10,72 +11,19 @@
 
    <select itemPath="json.results" produces="JSON">
       <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/category/{category}</url>
-      </urls>
-      <paging model="offset">
-        <start id="offset" default="0" />
-        <pagesize id="limit" max="50" />
-        <total default="10" />
-      </paging>
-      <inputs>
-        <key id="category" type="xs:string" paramType="path" required="true" />
-        <key id="api_key" type="xs:string" paramType="query" required="true" />
-        <key id="detail_level" type="xs:string" paramType="query" />
-        <key id="sort_order" type="xs:string" paramType="query" />
-        <key id="sort_on" type="xs:string" paramType="query" />
-      </inputs>
-   </select>
-
-   <select itemPath="json.results" produces="JSON">
-      <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/materials/{materials}</url>
-      </urls>
-      <paging model="offset">
-        <start id="offset" default="0" />
-        <pagesize id="limit" max="50" />
-        <total default="10" />
-      </paging>
-      <inputs>
-        <key id="materials" type="xs:string" paramType="path" required="true" />
-        <key id="api_key" type="xs:string" paramType="query" required="true" />
-        <key id="detail_level" type="xs:string" paramType="query" />
-        <key id="sort_order" type="xs:string" paramType="query" />
-        <key id="sort_on" type="xs:string" paramType="query" />
-      </inputs>
-   </select>
-
-   <select itemPath="json.results" produces="JSON">
-      <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/tags/{tags}</url>
-      </urls>
-      <paging model="offset">
-        <start id="offset" default="0" />
-        <pagesize id="limit" max="50" />
-        <total default="10" />
-      </paging>
-      <inputs>
-        <key id="tags" type="xs:string" paramType="path" required="true" />
-        <key id="api_key" type="xs:string" paramType="query" required="true" />
-        <key id="detail_level" type="xs:string" paramType="query" />
-        <key id="sort_order" type="xs:string" paramType="query" />
-        <key id="sort_on" type="xs:string" paramType="query" />
-      </inputs>
-   </select>
-
-   <select itemPath="json.results" produces="JSON">
-      <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/{listing_id}</url>
+        <url env="all">http://openapi.etsy.com/v2/public/listings/{listing_id}</url>
       </urls>
       <inputs>
         <key id="api_key" type="xs:string" paramType="query" required="true" />
         <key id="listing_id" type="xs:number" paramType="path" required="true"/>
-        <key id="detail_level" type="xs:string" paramType="query" />
       </inputs>
    </select>
 
+   <!-- Keeps compatibility with v1 table by using as attributes. -->
+
    <select itemPath="json.results" produces="JSON">
       <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/color/{color}{-prefix|/keywords/|search_terms}</url>
+        <url env="all">http://openapi.etsy.com/v2/public/listings/active</url>
       </urls>
       <paging model="offset">
         <start id="offset" default="0" />
@@ -84,26 +32,12 @@
       </paging>
       <inputs>
         <key id="api_key" type="xs:string" paramType="query" required="true" />
-        <key id="color" type="xs:string" paramType="path" required="true" />
-        <key id="search_terms" type="xs:string" paramType="path" />
-        <key id="wiggle" type="xs:number" paramType="query" />
-        <key id="detail_level" type="xs:string" paramType="query" />
-      </inputs>
-   </select>
-
-   <select itemPath="json.results" produces="JSON">
-      <urls>
-        <url env="all">http://beta-api.etsy.com/v1/listings/{-prefix|keywords/|search_terms}{-neg|all|search_terms}</url>
-      </urls>
-      <paging model="offset">
-        <start id="offset" default="0" />
-        <pagesize id="limit" max="50" />
-        <total default="10" />
-      </paging>
-      <inputs>
-        <key id="api_key" type="xs:string" paramType="query" required="true" />
-        <key id="search_terms" type="xs:string" paramType="path" required="true" />
-        <key id="detail_level" type="xs:string" paramType="query" />
+        <key id="keywords" as="search_terms" type="xs:string" paramType="query" />
+        <key id="color" type="xs:string" paramType="query" />
+        <key id="color_accuracy" as="wiggle" type="xs:number" paramType="query" />
+        <key id="materials" type="xs:string" paramType="query" />
+        <key id="category" type="xs:string" paramType="query" />
+        <key id="tags" type="xs:string" paramType="path" />
         <key id="min_price" type="xs:float" paramType="query" />
         <key id="max_price" type="xs:float" paramType="query" />
         <key id="search_description" type="xs:boolean" paramType="query" />


### PR DESCRIPTION
Etsy has shutdown their v1 API.

This patch keeps table keys backwards-compatible for existing table users. Old keys are translated to the new API by using @as.
