### PR TITLE
fixed typo on query example

### DIFF
--- a/data/data.cdn.xml
+++ b/data/data.cdn.xml
@@ -3,7 +3,7 @@
     <meta>
         <author>Marcel Duran</author>
         <description>Retrieves the list of CDNs or boolean values for a given list of hostnames or urls.</description>
-        <sampleQuery>select * from {table}"</sampleQuery>
+        <sampleQuery>select * from {table}</sampleQuery>
         <sampleQuery>select * from {table} where hostname in ("l.yimg.com","s3.amazonws.com")</sampleQuery>
         <sampleQuery>select * from {table} where url in ("http://l.yimg.com/foo.png","http://s3.amazonws.com/bar.png")</sampleQuery>
     </meta>


### PR DESCRIPTION
this is a minor change but the very first example comes with an extra double quote which raises an error
