### PR TITLE
charset fallback for data.headers, compression by default

### DIFF
--- a/data/data.headers.xml
+++ b/data/data.headers.xml
@@ -14,39 +14,32 @@
             </inputs>
             <execute>
                 <![CDATA[
-                    var resp, header, tag, redirect, location, redir, count, decodeError,
+                    var req, resp, header, tag, redirect, location, redir, count, content,
                         data = <resources/>,
                         headers = <headers/>,
                         reTagCase = /(^|\-)(\w)/g,
 
                         tagCase = function (a, b, c) {
                             return b + c.toUpperCase();
-                        },
-
-                        request = function (compress, charset) {
-                            y.log('request with' + (compress ? '' : 'out') + ' compression');
-                            var req = y.rest(url);
-
-                            // set user agent
-                            if (ua) {
-                                req.header('User-Agent', ua);
-                            }
-
-                            // compression
-                            if (compress) {
-                                req.header('Accept-Encoding', 'gzip,deflate');
-                                req.decompress(true);
-                            }
-
-                            if (charset) {
-                                req.forceCharset(charset);
-                            }
-
-                            // fetch url
-                            return req.get();
                         };
 
-                    resp = request(true);
+                    req = y.rest(url);
+
+                    // set user agent
+                    if (ua) {
+                        req.header('User-Agent', ua);
+                    }
+
+                    // compression
+                    req.header('Accept-Encoding', 'gzip,deflate');
+                    req.decompress(true);
+
+                    // bad servers don't set charset
+                    // YQL tries UTF-8 first then we try ISO as a fallback
+                    req.fallbackCharset('ISO-8859-1');
+
+                    // fetch url
+                    resp = req.get();
                     y.log('response length: ' + (resp.response && resp.response.length));
 
                     // check redirect
@@ -83,21 +76,23 @@
                     data.resources += <status>{resp.status}</status>;
                     data.resources += headers;
 
-                    // get uncompressed response for non-binary
-                    if ((header = resp.headers) && (header = header['content-type']) &&
-                            header.indexOf('image') && header.indexOf('x-shockwave-flash') < 0) {
-
-                        decodeError = y.diagnostics.url.(@['error'] == "Unable to parse data using default charset utf-8").(url == url);
-                        y.log('decode error: ' + decodeError);
-
-                        // try again with different charset if error occurs
-                        if (!resp.response && decodeError) {
-                            resp = request(false, 'ISO-8859-1');
-                            y.log('response iso length: ' + (resp.response && resp.response.length));
+                    // get uncompressed response content for non-binary
+                    header = resp.headers;
+                    header = (header && header['content-type']) || '';
+                    if (header.indexOf('image') && header.indexOf('x-shockwave-flash') < 0) {
+                        try {
+                            content = resp.response;
+                        } catch (err) {
+                            y.log(err);
+                            // empty response on error
+                            content = '';
                         }
+                    } else {
+                        // empty response for binaries
+                        content = '';
                     }
 
-                    data.resources += <content>{resp.response}</content>;
+                    data.resources += <content>{content}</content>;
 
                     response.maxAge = 300;
                     response.object = data;


### PR DESCRIPTION
added charset fallback, wrapped response in a try catch block to avoid binaries, set compression by default
YQL team has just released fallbackCharset method which is now used to avoid extra request/roundtrip.
