### PR TITLE
Associated Content tables

### DIFF
--- a/ac/ACF.xml
+++ b/ac/ACF.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd" securityLevel="any">
+  <meta>
+    <author>HOUYHNHNM</author>
+    <description>query can be anything type can be (c) contributors =1 (y) years =2(a) article types =3, if not set type is all =0.</description>
+    <documentationURL>http://pulse.yahoo.com/_VASY5CLHMAYFUT265F7HSL3YHE/blog/articles/269210</documentationURL>
+    <sampleQuery>select * from {table} where query="Yahoo" AND type="c"</sampleQuery>
+ </meta>
+  <bindings>
+    <select itemPath="" produces="XML">
+      <inputs>
+        <key id='query' type='xs:string' paramType='variable' required="true" />
+        <key id='type' type='xs:string' paramType='variable' required="false" />
+  </inputs>
+      <execute>
+      <![CDATA[ 
+
+	var querystr=query.replace(/\s/g,"%20");
+	var yqlstr1="select * from html where url=\"http://www.associatedcontent.com/subject/article/";
+	var rettype=0;
+	var yqlstr2="\" and xpath=\"//div[@class='search_filters']/p/select[@id='filter_select']/option\"";
+	if(type)
+	{
+		if(type.length==1)
+		{
+			if(type.match("c")!=null)
+			{
+				rettype=1;
+			}
+			else
+			{
+				if(type.match("y")!=null)
+				{
+					rettype=2;
+				}
+				else
+				{
+					if(type.match("a")!=null)
+					{
+						rettype=3;
+					}
+					else
+					{
+						;//
+					}
+				}
+			}
+		}
+		else
+		{
+			;//
+		}
+	}
+	else
+	{
+		;//
+	}
+	var yqlquery=y.query(yqlstr1+querystr+yqlstr2);
+	var yqlresults=yqlquery.results;
+	var yqlcounter=parseInt(yqlresults.option.length());
+	var xmlret=new XML();
+	xmlret=<root></root>;
+
+	var count=0;
+	var statemachine=0;
+	var value1="";
+	var value2="";
+	while(count<yqlcounter)
+	{
+		value1=new String(yqlresults.option[count].@value);
+		value2=new String(yqlresults.option[count].text());
+		if(statemachine==0)
+		{
+			if(value2.match("Contributors")!=null)
+			{
+				statemachine=1;
+			}
+			else
+			{
+				;//
+			}
+		}
+		else
+		{
+			if(statemachine==1)
+			{
+				if(value2.match("Year")!=null)
+				{
+					statemachine=2;
+				}
+				else
+				{
+					if((rettype==0)||(rettype==1))
+					{
+						if(value2.length>0)
+						{
+							value1=value1.match(/au=.+$/);
+							xmlret.root+=<contributor>
+								<username>{value2}</username>
+								<append>{value1}</append>
+							</contributor>
+						}
+						else
+						{
+							;//
+						}
+					}
+					else
+					{
+						;//
+					}
+				}
+			}
+			else
+			{
+				if(statemachine==2)
+				{
+					if(value2.match("Types")!=null)
+					{
+						statemachine=3;
+					}
+					else
+					{
+						if((rettype==0)||(rettype==2))
+						{
+							if(value2.length>0)
+							{
+								value1=value1.match(/ay=.+$/);
+								xmlret.root+=<year>
+									<value>{value2}</value>
+									<append>{value1}</append>
+								</year>
+							}
+							else
+							{
+								;//
+							}
+						}
+						else
+						{
+							;//
+						}
+					}
+				}
+				else
+				{
+					if(statemachine==3)
+					{
+						if((rettype==0)||(rettype==3))
+						{
+							if(value2.length>0)
+							{
+								value1=value1.match(/at=.+$/);
+								xmlret.root+=<articletype>
+									<type>{value2}</type>
+									<append>{value1}</append>
+								</articletype>
+							}
+							else
+							{
+								;//
+							}
+						}
+						else
+						{
+							;//
+						}
+						
+					}
+					else
+					{
+						;//
+					}
+				}
+			}
+		}
+		count++;
+	}
+	response.object=xmlret;
+
+ ]]>
+      </execute>
+    </select>
+  </bindings>
+</table>

--- a/ac/ACP.xml
+++ b/ac/ACP.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd" securityLevel="any">
+  <meta>
+    <author>HOUYHNHNM</author>
+    <description>content can be any string, contrib is the id of a contributor year is any year article is the id type of certain articles</description>
+    <documentationURL>http://pulse.yahoo.com/_VASY5CLHMAYFUT265F7HSL3YHE/blog/articles/269209</documentationURL>
+    <sampleQuery>select * from {table} where content="Harlem"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and contrib="29704"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and year="2010"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and article="43"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and article"43" and year"2010"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and article"43" and year"2010"</sampleQuery>
+    <sampleQuery>select * from {table} where content="Harlem" and year="2010" and article="43" and contrib="5069"</sampleQuery>
+ </meta>
+  <bindings>
+    <select itemPath="" produces="XML">
+      <inputs>
+        <key id='content' type='xs:string' paramType='variable' required="true" />
+        <key id='contrib' type='xs:string' paramType='variable' required="false" />
+        <key id='year' type='xs:string' paramType='variable' required="false" />
+        <key id='article' type='xs:string' paramType='variable' required="false" />
+  </inputs>
+      <execute>
+      <![CDATA[ 
+
+	var querystr=content.replace(/\s/g,"%20");
+	var yqlstr1="select * from html where url=\"http://www.associatedcontent.com/subject/article/";
+	var contribval;
+	var yearval;
+	var articleval;
+	var setter=false;
+	var stringroot="";
+	var d = new Date();
+	var dyear=d.getFullYear()+1;
+	var yqlstr2="\" and xpath=\"//select[@id='pagerRSBot']/option|//div[@class='byline']\"";
+	if(contrib)
+	{
+		contribval=parseInt(contrib);
+		if(contribval>0)
+		{
+			setter=true;
+			contribval=stringroot.concat("?au=",contrib);
+		}
+		else
+		{
+			contribval="";
+		}
+	}
+	else
+	{
+		contribval="";
+	}
+	if(year)
+	{
+		yearval=parseInt(year);
+		if((yearval>1963)&&(yearval<dyear))
+		{
+			if(setter)
+			{
+				yearval=stringroot.concat("&ay=",year);
+			}
+			else
+			{
+				setter=true;
+				yearval=stringroot.concat("?ay=",year);
+			}
+		}
+		else
+		{
+			yearval="";
+		}
+	}
+	else
+	{
+		yearval="";
+	}
+	if(article)
+	{
+		articleval=parseInt(article);
+		if(articleval>0)
+		{
+			if(setter)
+			{
+				articleval=stringroot.concat("&at=",article);
+			}
+			else
+			{
+				setter=true;
+				articleval=stringroot.concat("?at=",article);
+			}
+		}
+		else
+		{
+			articleval="";
+		}
+	}
+	else
+	{
+		articleval="";
+	}
+
+	var yqlquery=y.query(yqlstr1+querystr+contribval+yearval+articleval+yqlstr2);
+	var yqlresults=yqlquery.results;
+	var yqlcounter=parseInt(yqlresults.option.length());
+	var existcheck1;
+	var existcheck2;
+	var xmlret=new XML();
+	xmlret=<root></root>;
+	var minval=1;
+	var maxval=yqlcounter/2;
+	if(maxval>0)
+	{
+	xmlret.root+=<pagevalues>
+		<min>{minval}</min>
+		<max>{maxval}</max>
+	</pagevalues>
+	}
+	else
+	{
+		if(contribval.length>0)
+		{
+			existcheck1=yqlresults.div[0].p.a.@href;
+			if(existcheck1.match(contrib)!=null)
+			{
+				xmlret.root+=<pagevalues>
+					<pages>1</pages>
+				</pagevalues>
+			}
+			else
+			{
+				xmlret.root+=<pagevalues>
+					<retmessage>User does not have entries under subject or exist</retmessage>
+				</pagevalues>
+			}
+		}
+		else
+		{
+			if(yearval.length>0)
+			{
+				existcheck2=String(yqlresults.div[0].p.text());
+				if(existcheck2.match(year)!=null)
+				{
+					xmlret.root+=<pagevalues>
+						<pages>1</pages>
+					</pagevalues>
+				}
+				else
+				{
+					xmlret.root+=<pagevalues>
+						<retmessage>No entries made during the year for the subject</retmessage>
+					</pagevalues>
+				}
+			}
+			else
+			{
+				xmlret.root+=<pagevalues>
+					<retmessage>Article type has only one page to return for subject or article type ID is wrong</retmessage>
+				</pagevalues>
+			}
+		}
+	}
+	response.object=xmlret;
+
+ ]]>
+      </execute>
+    </select>
+  </bindings>
+</table>


### PR DESCRIPTION
These are associated content tables. ACF finds out the filters for a given search. The filters are contributors, years and article types.
You can use the key type to get one of them with the values c,y, or a

ACP is to get the number of pages with a query

The final table, search is in process
