### PR TITLE
removed redirects count divisor

### DIFF
--- a/data/data.headers.xml
+++ b/data/data.headers.xml
@@ -46,7 +46,6 @@
                     redirect = y.diagnostics.redirect;
                     count = redirect && redirect.length();
                     if (count) {
-                        count = (count % 2) ? count : count / 2;
                         for (i = 0; i < count; i += 1) {
                             redir = redirect[i];
                             y.log('redirect: ' + redir.@status + ' = ' + redir.toString());


### PR DESCRIPTION
previously yql was returning duplicate number of redirects, seems to be fixed now
