### PR TITLE
YQL table for W3C validation service

### DIFF
--- a/w3c/w3c.check.xml
+++ b/w3c/w3c.check.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+  <meta>
+    <author>Rodrigo Setti (rsetti@yahoo-inc.com)</author>
+    <description>Validate web documents using W3C's validator</description>
+    <documentationURL>http://validator.w3.org/docs/api.html</documentationURL>
+    <sampleQuery>select * from {table} where uri='www.yahoo.com'</sampleQuery>
+  </meta>
+  <bindings>
+    <select itemPath="" produces="XML">
+      <urls>
+        <url>http://{validator}/check</url>
+      </urls>
+      <inputs>
+        <key id="uri" type="xs:string" paramType="query" />
+        <key id="output" type="xs:string" paramType="query" default="soap12"/>
+        <key id="validator" type="xs:string" paramType="path" default="validator.w3.org"/>
+      </inputs>
+    </select>
+  </bindings>
+</table>


### PR DESCRIPTION
Created an absurdly simple but usable YQL table to serve W3C's markup validation service. Example usage:

select \* from w3c.check where uri="www.yahoo.com"

By default it returns a SOAP 1.2 xml in result, but when ouput="html", then a html is returned.

It is possible to set "validator" parameter in where clause to set a different validation host (where fech will be on <host>/check), which, by default is "validator.w3c.org"
