### PR TITLE
Add the ability to include retweets in a twitter user timeline

### DIFF
--- a/twitter/twitter.user.timeline.xml
+++ b/twitter/twitter.user.timeline.xml
@@ -20,6 +20,7 @@
         <key id="since_id" type="xs:string" paramType="query" />
         <key id="id" type="xs:string" paramType="query" required="false" />
         <key id="screen_name" type="xs:string" paramType="query" required="false" />
+        <key id="include_rts" type="xs:string" paramType="query" required="false" />
         <key id="format" type="xs:string" paramType="path" required="false" default="xml"/>
       </inputs>
     </select>


### PR DESCRIPTION
Afaik you currently can't include retweets in a twitter user timeline. (via yql)
This change would allow you to do so.

You can find more about the api at https://dev.twitter.com/docs/api/1/get/statuses/user_timeline
