### PR TITLE
yahoo.finance.option_contracts.xml

### DIFF
--- a/yahoo/finance/yahoo.finance.option_contracts.xml
+++ b/yahoo/finance/yahoo.finance.option_contracts.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+  <meta>
+    <author>
+      Alan Verga
+    </author>
+    <description>
+      Yahoo Finance Quotes - Options Contract Months
+    </description>
+    <sampleQuery>
+      SELECT * FROM {table} WHERE symbol='YHOO'
+    </sampleQuery>
+  </meta>
+  <bindings>
+    <select itemPath="" produces="XML">
+      <urls>
+	<url>
+	</url>
+      </urls>
+      <inputs>
+	<key id="symbol" type="xs:string" paramType="variable" required="true" />
+      </inputs>
+      <execute>
+	<![CDATA[
+	
+	    function getContracts()
+	    {
+		var results = optionsPath;
+
+		elements = results.*.length();
+
+		if ( elements == 0 )
+		{
+		    return false;
+		}
+
+		var yearRegEx = /\d{4}/;
+		var monthRegEx = /\-\d{2}/;
+
+		for each ( var a in results )
+		{
+		    //grab the link w/ href containing date
+		    var contract = a.@href.text();
+
+		    //YYYY-MM format
+		    var result = yearRegEx.exec(contract) + monthRegEx.exec(contract);
+
+		    var contractElem = <contract>{result}</contract>;
+
+		    //maintain sorted ordering by date
+		    if (a == results[results.length()-1]) {
+			contractList.prependChild( contractElem );
+		    }
+		    else {
+			contractList.appendChild( contractElem );
+		    }
+
+		}	    
+		return true;
+	    }
+
+
+	    //build the query string
+	    var StockquoteURL = "http://finance.yahoo.com/q/op?s=" + symbol;
+
+	    //get thy results
+	    var yQuery = y.rest( StockquoteURL );	
+	    var data = yQuery.accept( "text/html" ).get().response;
+
+	    //grab the appropriate path
+	    var optionsPath = y.xpath(data, "//table[@id='yfncsumtab']/tr/td/table/tr/td/p/a");
+
+	    var contractList = <option symbol={symbol}></option>;
+
+	    getContracts();
+
+	    response.object = contractList;
+	]]>
+      </execute>
+    </select>
+  </bindings>
+</table>


### PR DESCRIPTION
yahoo.finance.option_contracts lists what option contracts are active (has trade information) for a specific ticker.

The yahoo.finance.options datatable provides detailed quote information, but requires users to know the contract month(s) for the expiration attribute in the query beforehand.  It is often the case that users want to know what option contracts contain data prior to making a query; as such a simple contract dump is useful.

Really basic, but I found I needed the information and couldn't find it in the community tables.

best
vergeman
