### PR TITLE
Add OAuth 2.0 token support to facebook.fql.query.xml

### DIFF
--- a/facebook/facebook.fql.query.xml
+++ b/facebook/facebook.fql.query.xml
@@ -1,2 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd"><meta><author>Sam Pullara</author><documentationURL>http://wiki.developers.facebook.com/index.php/Fql.query</documentationURL></meta><bindings><select itemPath="" produces="XML"><urls><url>http://api.facebook.com/restserver.php</url></urls><inputs><key id="secret" paramType="variable" required="true" type="xs:string"/><key id="fb_sig_session_key" paramType="variable" required="true" type="xs:string"/><key id="fb_sig_api_key" paramType="variable" required="true" type="xs:string"/><key id="query" paramType="variable" type="xs:string"/></inputs><execute>y.include("http://www.javarants.com/facebook/facebook.js");var params = {call_id: "" + new Date().getTime(),v: "1.0",api_key: fb_sig_api_key,session_key: fb_sig_session_key,format: "xml",query:query,method: "Fql.query"};response.object = y.rest("http://api.facebook.com/restserver.php").contentType("application/x-www-form-urlencoded").post(sign(params)).response;</execute></select></bindings></table><!-- yqlengine2.pipes.sp1.yahoo.com uncompressed/chunked Thu Sep 10 20:59:25 PDT 2009 -->
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+    <meta>
+        <author>Sam Pullara</author>
+        <documentationURL>http://wiki.developers.facebook.com/index.php/Fql.query</documentationURL>
+    </meta>
+    <bindings>
+        <select itemPath="" produces="XML">
+            <urls>
+                <url>http://api.facebook.com/restserver.php</url>
+            </urls>
+            <inputs>
+                <key id="secret" paramType="variable" required="true" type="xs:string"/>
+                <key id="fb_sig_session_key" paramType="variable" required="true" type="xs:string"/>
+                <key id="fb_sig_api_key" paramType="variable" required="true" type="xs:string"/>
+                <key id="query" paramType="variable" type="xs:string"/>
+            </inputs>
+            <execute>
+                y.include("http://www.javarants.com/facebook/facebook.js");
+                var params = {call_id: "" + new Date().getTime(),v: "1.0",api_key: fb_sig_api_key,session_key: fb_sig_session_key,format: "xml",query:query,method: "Fql.query"};
+                response.object = y.rest("http://api.facebook.com/restserver.php").contentType("application/x-www-form-urlencoded").post(sign(params)).response;
+            </execute>
+        </select>
+        <select itemPath="" produces="XML">
+            <urls>
+                <url>https://api.facebook.com/method/fql.query</url>
+            </urls>
+            <inputs>
+                <key id="query" type="xs:string" paramType="query" required="true" />
+                <key id="access_token" type="xs:string" paramType="query" required="true"/>
+            </inputs>
+        </select>
+        <select itemPath="" produces="XML">
+            <urls>
+                <url>http://api.facebook.com/method/fql.query</url>
+            </urls>
+            <inputs>
+                <key id="query" type="xs:string" paramType="query" required="true" />
+            </inputs>
+        </select>
+    </bindings>
+</table><!-- yqlengine2.pipes.sp1.yahoo.com uncompressed/chunked Thu Sep 10 20:59:25 PDT 2009 -->


### PR DESCRIPTION
facebook.fql.query.xml updated to allow OAuth 2.0 access_token support (also re-formatted existing XML to improve readability)
