### PR TITLE
making pagination work for twitter.search

### DIFF
--- a/twitter/twitter.search.xml
+++ b/twitter/twitter.search.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <table xmlns="http://query.yahooapis.com/v1/schema/table.xsd" https="false">
 	<meta>
-		<author>Zach Graves (zachg@yahoo-inc.com)</author>
-		<description>Twitter OAuth API</description>
-		<documentationURL>http://apiwiki.twitter.com/Twitter-API-Documentation</documentationURL>
-		<sampleQuery>select * from {table} where q='earthquake';</sampleQuery>
+		<author>
+			Zach Graves (zachg@yahoo-inc.com).
+			Update 09/16/100: Sebastian Spier (http://twitter.com/#!/sebastianspier/)
+		</author>
+		<description>Search - Twitter OAuth API</description>
+		<documentationURL>https://dev.twitter.com/docs/api/1/get/search</documentationURL>
+		<sampleQuery>SELECT * FROM {table} WHERE q='earthquake'</sampleQuery>
 	</meta>
 	<bindings>
 		<select itemPath="json.results" produces="JSON">
 			<urls>
-				<url>http://search.twitter.com/search.{format}</url>
+				<url>http://search.twitter.com/search.json</url>
 			</urls>
 			<paging model="page">
 				<start id="page" default="1" />
@@ -22,13 +25,31 @@
 				<key id="geocode" type="xs:string" paramType="query" required="false"/>
 				<key id="lang" type="xs:string" paramType="query" required="false"/>
 				<key id="locale" type="xs:string" paramType="query" required="false"/>
-				<key id="rpp" type="xs:string" paramType="query" required="false"/>
-				<key id="page" type="xs:string" paramType="query" required="false"/>
-				<key id="since_id" type="xs:string" paramType="query" required="false"/>
-				<key id="max_id" type="xs:string" paramType="query" required="false"/>
-				<key id="show_user" type="xs:string" paramType="query" required="false" default="false"/>
 				
-				<key id="format" type="xs:string" paramType="path" default="json" private="true"/>
+				<!-- the following two keys should not be exposed here, as they are part of the pagination element -->
+				<!-- 
+					<key id="rpp" type="xs:string" paramType="query" required="false"/>
+				<key id="page" type="xs:string" paramType="query" required="false"/> 
+				-->
+				
+				<key id="result_type" type="xs:string" paramType="query" required="false" description="mixed/recent/popular"/>
+				
+				<!-- 
+					Removed default="false", because I think that this parameter is buggy. Prepends username no
+				 	matter if show_user is set to true or to false.
+				-->
+				<key id="show_user" type="xs:string" paramType="query" required="false" />
+				
+				<!-- Optional. Returns tweets generated before the given date. Date should be formatted as YYYY-MM-DD. -->
+				<key id="until" type="xs:string" paramType="query" required="false"/>
+				
+				<key id="since_id" type="xs:string" paramType="query" required="false"/>
+				
+				<!-- no longer exists -->
+				<!-- <key id="max_id" type="xs:string" paramType="query" required="false"/> -->
+				
+				<!-- format should not be configurable, as the YQL table could not handle ATOM data anyways -->
+				<!-- <key id="format" type="xs:string" paramType="path" default="json" private="true" description="atom/json"/> -->
 			</inputs>
 		</select>
 	</bindings>


### PR DESCRIPTION
Enable to retrieve more than 100 results from twitter in once call.
Example:
select \* from twitter.search(0,500) where q="twitter"
