### PR TITLE
Added Guardian politics tables

### DIFF
--- a/guardian/guardian.politics.candidates.xml
+++ b/guardian/guardian.politics.candidates.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+	<meta>
+		<author>Steve King steve@stevenking.com.au</author>
+		<description>There is a lot of data returned by this endpoint. It gives you all of the candidates who took part in a specific election. This information is grouped by constituency.</description>
+		<documentationURL>http://www.guardian.co.uk/open-platform/politics-api/getting-started</documentationURL>
+		<sampleQuery>SELECT * FROM {table} WHERE year=1992</sampleQuery>
+	</meta>
+	<bindings>
+		<select itemPath="json.constituencies" produces="JSON">
+			<urls>
+				<url>http://www.guardian.co.uk/politics/api/general-election/{year}/candidates/json</url>
+			</urls>
+			<inputs>
+        		<key id="year" type="xs:string" paramType="path" required="true" />
+			</inputs>
+		</select>
+	</bindings>
+</table>

--- a/guardian/guardian.politics.elections.xml
+++ b/guardian/guardian.politics.elections.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+	<meta>
+		<author>Steve King steve@stevenking.com.au</author>
+		<description>This is another catalogue endpoint which will return a collection of General Election entities.</description>
+		<documentationURL>http://www.guardian.co.uk/open-platform/politics-api/getting-started</documentationURL>
+		<sampleQuery>SELECT * FROM {table}</sampleQuery>
+	</meta>
+	<bindings>
+		<select itemPath="json.elections" produces="JSON">
+			<urls>
+				<url>http://www.guardian.co.uk/politics/api/general-election/all/json</url>
+			</urls>
+		</select>
+	</bindings>
+</table>

--- a/guardian/guardian.politics.parties.xml
+++ b/guardian/guardian.politics.parties.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+	<meta>
+		<author>Steve King steve@stevenking.com.au</author>
+		<description>This endpoint provides a basic listing of political party entities.</description>
+		<documentationURL>http://www.guardian.co.uk/open-platform/politics-api/getting-started</documentationURL>
+		<sampleQuery>SELECT * FROM {table}</sampleQuery>
+	</meta>
+	<bindings>
+		<select itemPath="json.parties" produces="JSON">
+			<urls>
+				<url>http://www.guardian.co.uk/politics/api/party/all/json</url>
+			</urls>
+		</select>
+	</bindings>
+</table>

--- a/guardian/guardian.politics.party.xml
+++ b/guardian/guardian.politics.party.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+	<meta>
+		<author>Steve King steve@stevenking.com.au</author>
+		<description>Using this endpoint will return all of the current MPs within the selected political party and the constituency they represent.</description>
+		<documentationURL>http://www.guardian.co.uk/open-platform/politics-api/getting-started</documentationURL>
+		<sampleQuery>SELECT * FROM {table} WHERE pid=152</sampleQuery>
+	</meta>
+	<bindings>
+		<select itemPath="json.party" produces="JSON">
+			<urls>
+				<url>http://www.guardian.co.uk/politics/api/party/{pid}/json</url>
+			</urls>
+			<inputs>
+        		<key id="pid" type="xs:string" paramType="path" required="true" />
+			</inputs>
+		</select>
+	</bindings>
+</table>

--- a/guardian/guardian.politics.results.xml
+++ b/guardian/guardian.politics.results.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<table xmlns="http://query.yahooapis.com/v1/schema/table.xsd">
+	<meta>
+		<author>Steve King steve@stevenking.com.au</author>
+		<description> It includes information about the successful MP at that General Election and the previous MP of the constituency. It also provides information about the contest such as the voting turnout, winning margin and the exact time the result was declared.</description>
+		<documentationURL>http://www.guardian.co.uk/open-platform/politics-api/getting-started</documentationURL>
+		<sampleQuery>SELECT * FROM {table} WHERE year=1992</sampleQuery>
+	</meta>
+	<bindings>
+		<select itemPath="json.results.called-constituencies" produces="JSON">
+			<urls>
+				<url>http://www.guardian.co.uk/politics/api/general-election/{year}/results/json</url>
+			</urls>
+			<inputs>
+				<key id="year" type="xs:string" paramType="path" required="true" />
+			</inputs>
+		</select>
+	</bindings>
+</table>


### PR DESCRIPTION
Added Guardian politics tables. 

You can read more about the table here: http://www.guardian.co.uk/open-platform/politics-api/getting-started

Didn't add the following tables (but will soon) as soon as they are fixed on the Guardian API:
/politics/api/person/1276/json
/politics/api/constituency/all/json
/politics/api/constituency/664/json
