### PR TITLE
Fix for Yahoo Finance Options strike prices with commas

### DIFF
--- a/yahoo/finance/yahoo.finance.options.xml
+++ b/yahoo/finance/yahoo.finance.options.xml
@@ -91,7 +91,7 @@
 
 				for each ( var tr in results )
 				{
-					strikePrice = parseFloat( tr.td[0].a.strong.text() );
+					strikePrice = parseFloat( tr.td[0].a.strong.text().toString().replace(/\,/g,'') );
 					optionSymbol = tr.td[1].a.text();
 					
 					// Check to see what type of option


### PR DESCRIPTION
This commit fixes the parsing of strike prices that have commas in them, so now, something like 1,050.00 is correctly parsed to 1050 instead of 1.
