### PR TITLE
Fixes yahoo.finance.industry

### DIFF
--- a/yahoo/finance/yahoo.finance.industry.xml
+++ b/yahoo/finance/yahoo.finance.industry.xml
@@ -9,7 +9,7 @@
   <bindings>
     <select itemPath="" produces="XML">
       <urls>
-       <url>http://biz.yahoo.com/ic/{id}_cl_pub.html</url>
+       <url>http://biz.yahoo.com/p/{id}conameu.html</url>
       </urls>
       <inputs>
 	<key id="id" type='xs:string' paramType='path' required='true'/>
@@ -29,24 +29,21 @@
 	"select * from html " +
 	"where url=@url and " + 
 	"xpath='" +
-	"//table[@width=\"100%\"]/tr/td/font[@size=\"-1\"]/strong | " +
-	"//td[@width=\"50%\"]//font[@size=\"-1\"]/a'",
+	"//tr/td/font[@face=\"arial\" and a[contains(@href,\"finance\")]] |" + 
+	"//tr/td/font[a/@href=\"http://biz.yahoo.com/ic/"+id+".html\"]/strong'",
 	{url:request.url});
     var results = industryQuery.results;
 
-    var name = results.strong.a[1].text().toString().trim().replace(/\s+/g, " ");
+    var name = results.strong.text().toString().replace(/>/g,'').trim();
     var industry = <industry id={id} name={name}/>;
 
-    for each (var a in results.a){
-	match = a.@href.toString().match(/q\?s=(.*)$/);
-	if (match == null) {
-	    companyName = a.text().toString().trim();
-	    companyName = companyName.replace(/\s+/g, " ");
-	} else {
-	    symbol = match[1];
-	    company = <company symbol={symbol} name={companyName} />
-	    industry.appendChild(company);
-	}
+    for each (var company in results.font){
+	companyName = company.a[0];
+	symbol = company.a[1];
+	if(symbol == undefined)
+	    symbol = company.text().toString().replace(/[()]/g,'').trim();
+    	company = <company symbol={symbol} name={companyName} />
+    	industry.appendChild(company);
     }
     
     response.object = industry;


### PR DESCRIPTION
Points to the main industry browser page, I think the old url was deprecated.

After further testing, this breaks on certain ids (like 133) because the page is above the 1.5MB limit of yql.  I have attempted to bypass yql and do a direct y.rest with gzip encoding, but the response turns out to be malformed (many html characters appear as their entity name, rather than their character).

However, this is still better than the original, which returned only a small fraction of the information available.
