### PR TITLE
fix finance.historicaldata to return symbol

### DIFF
--- a/yahoo/finance/yahoo.finance.historicaldata.xml
+++ b/yahoo/finance/yahoo.finance.historicaldata.xml
@@ -56,7 +56,7 @@
 				var quotes = <quotes/>;
 				rows=results.results.row;
 				for each (var row in rows) {
-					quotes.quote += <quote date={row.Date.text().toString()}>{row.*}</quote>;
+					quotes.quote += <quote Symbol={symbol}>{row.*}</quote>;
 				}
 				response.object = quotes;
 				


### PR DESCRIPTION
Instead of returning the date twice in the response struct, replace first date element with symbol. This adds support for YQL "symbol IN (a,b,c)" functionality.
