### PR TITLE
Fix the crawling of Yahoo Finance option page to reflect a layout change...

### DIFF
--- a/yahoo/finance/oquote/yahoo.finance.oquote.xml
+++ b/yahoo/finance/oquote/yahoo.finance.oquote.xml
@@ -46,8 +46,8 @@ if (summary.hasComplexContent()) {
 
     quote.appendChild(<prevClose>{quoteList.tr[0].td.p.text()}</prevClose>);
     quote.appendChild(<open>{quoteList.tr[1].td.p.text()}</open>);
-    quote.appendChild(<bid>{quoteList.tr[2].td.p.text()}</bid>);
-    quote.appendChild(<ask>{quoteList.tr[3].td.p.text()}</ask>);
+    quote.appendChild(<bid>{quoteList.tr[2].td.span.text()}</bid>);
+    quote.appendChild(<ask>{quoteList.tr[3].td.span.text()}</ask>);
     quote.appendChild(<strike>{quoteList.tr[4].td.p.text()}</strike>);
     quote.appendChild(<expire>{quoteList.tr[5].td.p.text()}</expire>);
     // quote.appendChild(<daysRange>{quoteList.tr[6].td.p.text()}</daysRange>);


### PR DESCRIPTION
... so we can get the ask and bid price again.

Can verify the fix by executing the YQL query in the console: 
http://developer.yahoo.com/yql/console/ using the revised query

use "store://spHclBldle1Fcn1EWfxOZs" as yahoo.finance.oquote2; 
SELECT \* FROM yahoo.finance.oquote2 WHERE symbol IN ("MSFT")

Compare that to the existing version: 
SELECT \* FROM yahoo.finance.oquote WHERE symbol IN ("MSFT")

Note that the prod version is missing bid and ask prices in the returned results.
