### PR TITLE
Fix yahoo finance oquote table to reflect change in a div class

### DIFF
--- a/yahoo/finance/oquote/yahoo.finance.oquote.xml
+++ b/yahoo/finance/oquote/yahoo.finance.oquote.xml
@@ -36,7 +36,7 @@ var summaryXpath = "//div[@class='yfi_rt_quote_summary_rt_top sigfig_promo_1']",
 var summary = y.xpath(data, summaryXpath),
     price = y.xpath(data, priceXpath).text(),
     change = y.xpath(data, changeXpath).text(),
-	quoteList = y.xpath(data, quoteListXpath);
+    quoteList = y.xpath(data, quoteListXpath);
 			
 if (summary.hasComplexContent()) {
     var quote = <option sym={symbol}></option>;


### PR DESCRIPTION
During the week of 3/3/14 yahoo changed the finance quote pages such that this:
class='yfi_rt_quote_summary_rt_top'

was changed to:
class='yfi_rt_quote_summary_rt_top sigfig_promo_1'

it was necessary to reflect this change in oquote in order for it to return any results. 
