### PR TITLE
Add support for UTF-8 characters

### DIFF
--- a/google/google.translate.xml
+++ b/google/google.translate.xml
@@ -6,7 +6,7 @@
   <bindings>
     <select itemPath="json" produces="JSON">
       <urls>
-        <url>http://translate.google.com/translate_a/t?client=x&amp;text={q}&amp;sl={source}&amp;tl={target}</url>
+        <url>http://translate.google.com/translate_a/t?client=x&amp;text={q}&amp;sl={source}&amp;tl={target}&amp;ie=UTF-8</url>
       </urls>
       <inputs>
         <key id='q' type='xs:string' paramType='query' required="true" />


### PR DESCRIPTION
This enables support for non-Latin alphabet languages such as Chinese, Japanese, Korean. Otherwise, Google Translate misinterprets the input and attempts to translate the misinterpretation.
