### PR TITLE
Add YQL table for App Links index

### DIFF
--- a/applinks/applinks.xml
+++ b/applinks/applinks.xml
@@ -17,7 +17,7 @@
             <execute>
                 <![CDATA[
                     var url       = inputs['url'],
-                        platforms = ['ios', 'iphone', 'ipad', 'android', 'windows_phone', 'web', 'blackberry'],
+                        platforms = ['ios', 'iphone', 'ipad', 'android', 'windows_phone', 'web'],
                         query     = y.query("select * from html where url = \"" + url 
                                      + "\" and compat = 'html5' and xpath='//meta[contains(@property, \"al:\")]'")
                                      .format('json');


### PR DESCRIPTION
This YQL table lets you batch together multiple URLs to let YQL parse and cache [App Links](http://applinks.org/) metadata for you.

Example:

``` sql
SELECT url, android.url FROM applinks WHERE url IN ("movietickets.com", "pinterest.com")
```

Would produce these results in XML:

``` xml
<results>
    <applinks>
        <android>
            <url>movietickets://home</url>
        </android>
        <url>movietickets.com</url>
    </applinks>
    <applinks>
       <android>
           <url>pinterest://</url>
        </android>
        <url>pinterest.com</url>
    </applinks>
</results>
```

And these JSON results:

``` json
{
  "results":{
    "applinks":[
      {
        "android":{
          "url":"movietickets://home"
        },
        "url":"movietickets.com"
      },
      {
        "android":{
          "url":"pinterest://"
        },
        "url":"pinterest.com"
      }
    ]
  }
}
```
