### PR TITLE
Fix url yahoo maps

### DIFF
--- a/yahoo/maps/yahoo.maps.findLocation.xml
+++ b/yahoo/maps/yahoo.maps.findLocation.xml
@@ -8,7 +8,7 @@
   <bindings>
     <select itemPath="" produces="JSON">
       <urls>
-        <url>http://gws.maps.yahoo.com/FindLocation</url>
+        <url>http://gws2.maps.yahoo.com/FindLocation</url>
       </urls>
       <inputs>
         <!-- 


### PR DESCRIPTION
Old: http://gws.maps.yahoo.com/FindLocation
New: http://gws2.maps.yahoo.com/FindLocation
